### PR TITLE
Fix issue #55

### DIFF
--- a/methods-distance/src/main/java/com/github/sevntu/checkstyle/analysis/AnalysisUtils.java
+++ b/methods-distance/src/main/java/com/github/sevntu/checkstyle/analysis/AnalysisUtils.java
@@ -44,6 +44,8 @@ public final class AnalysisUtils {
                 result = true;
                 break;
             case TokenTypes.LITERAL_NEW:
+                result = !isAnonymousClassDef(parent);
+                break;
             case TokenTypes.INTERFACE_DEF:
                 result = false;
                 break;
@@ -115,5 +117,17 @@ public final class AnalysisUtils {
             }
         }
         return result;
+    }
+
+    /**
+     * Whether the AST is a definition of an anonymous class.
+     *
+     * @param ast the AST to process.
+     * @return true if the AST is a definition of an anonymous class.
+     */
+    private static boolean isAnonymousClassDef(DetailAST ast) {
+        final DetailAST lastChild = ast.getLastChild();
+        return lastChild != null
+            && lastChild.getType() == TokenTypes.OBJBLOCK;
     }
 }

--- a/methods-distance/src/test/java/com/github/sevntu/checkstyle/analysis/MethodCallDependencyCheckstyleModuleTest.java
+++ b/methods-distance/src/test/java/com/github/sevntu/checkstyle/analysis/MethodCallDependencyCheckstyleModuleTest.java
@@ -239,4 +239,16 @@ public class MethodCallDependencyCheckstyleModuleTest extends
                 .get();
         verifyInfo(dc, "InputAbstractClass.java", dependencies);
     }
+
+    @Test
+    public void testMethodCallChildOfNew() throws Exception {
+        final DefaultConfiguration dc =
+            createCheckConfig(MethodCallDependencyCheckstyleModule.class);
+        final ExpectedDependencies expected = ExpectedDependencies.build()
+                .method("foo()")
+                .callsTo(1).at(6, 7)
+                .method("bar()")
+                .get();
+        verifyInfo(dc, "InputMethodCallChildOfNew.java", expected);
+    }
 }

--- a/methods-distance/src/test/resources/com/github/sevntu/checkstyle/analysis/InputMethodCallChildOfNew.java
+++ b/methods-distance/src/test/resources/com/github/sevntu/checkstyle/analysis/InputMethodCallChildOfNew.java
@@ -1,0 +1,13 @@
+package com.github.sevntu.checkstyle.domain;
+
+public class InputMethodCallChildOfNew {
+
+    private void foo() {
+        int[] tab = new int[bar() + 1];
+        int x = new Integer(3*bar());
+    }
+
+    public int bar() {
+        return 1;
+    }
+}


### PR DESCRIPTION
Resolve #55 
- Report before fix: https://wilcoln.github.io/com.pupppycrawl.tools.checkstyle.api/after.FileText.java.html
- Report after fix: https://wilcoln.github.io/com.pupppycrawl.tools.checkstyle.api/after.fix.FileText.java.html

I would like to mention that the `isAnonymousClassDef` method is already defined in `RequireThisCheck` (Cf checkstyle main repo), as you might recall, I'm working on refactoring this check in order to extract some common logic to utility classes like `TokenUtil` and a new `FrameUtil`. 
As for the method  `isAnonymousClassDef`, I'm planning to place it inside `TokenUtil`.

Once it's done, line 47 of `AnalysisUtils.java` will become
 ```java
result = !TokenUtil.isAnonymousClassDef(parent);
 ```