### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/methods-distance/src/main/java/com/github/sevntu/checkstyle/ordering/MethodOrder.java
+++ b/methods-distance/src/main/java/com/github/sevntu/checkstyle/ordering/MethodOrder.java
@@ -388,7 +388,7 @@ public class MethodOrder {
         }
     }
 
-    private class AppearanceOrderMethodInvocationComparator
+    private final class AppearanceOrderMethodInvocationComparator
         implements Comparator<MethodInvocation> {
 
         @Override
@@ -411,7 +411,7 @@ public class MethodOrder {
         }
     }
 
-    private static class UniqueCallerCalleeMethodInvocationFilter
+    private static final class UniqueCallerCalleeMethodInvocationFilter
         implements Predicate<MethodInvocation> {
 
         private final Set<MethodInvocation> set = new TreeSet<>(new Comparator<MethodInvocation>() {

--- a/methods-distance/src/test/java/com/github/sevntu/checkstyle/analysis/MethodCallDependenciesModuleTestSupport.java
+++ b/methods-distance/src/test/java/com/github/sevntu/checkstyle/analysis/MethodCallDependenciesModuleTestSupport.java
@@ -124,7 +124,8 @@ public class MethodCallDependenciesModuleTestSupport extends BaseCheckTestSuppor
         return new MethodOrder(withDefaultConfig(fileName));
     }
 
-    private static class DependencyInformationCollector implements DependencyInformationConsumer {
+    private static final class DependencyInformationCollector
+            implements DependencyInformationConsumer {
 
         private Map<String, Dependencies> filePathToDependencies = new HashMap<>();
 


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.